### PR TITLE
Avoid shutting down RLottie in the Unity Editor

### DIFF
--- a/Runtime/RLottie/RLottie.cs
+++ b/Runtime/RLottie/RLottie.cs
@@ -299,7 +299,9 @@ namespace Gilzoide.LottiePlayer.RLottie
         static RLottieCApi()
         {
             lottie_init();
+#if !UNITY_EDITOR
             Application.quitting += Shutdown;
+#endif
         }
 
         private static void Shutdown()

--- a/Runtime/RLottie/RLottie.cs
+++ b/Runtime/RLottie/RLottie.cs
@@ -299,15 +299,6 @@ namespace Gilzoide.LottiePlayer.RLottie
         static RLottieCApi()
         {
             lottie_init();
-#if !UNITY_EDITOR
-            Application.quitting += Shutdown;
-#endif
-        }
-
-        private static void Shutdown()
-        {
-            lottie_shutdown();
-            Application.quitting -= Shutdown;
         }
     }
 }


### PR DESCRIPTION
This fixes freezes after restarting Play mode. Fixes #16.